### PR TITLE
⚙️  Chore: tailwind 컬러 팔레트 및 반응형 브레이크 포인트 세팅

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# tailwind.config.ts 파일 무시
+tailwind.config.ts

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,17 +1,41 @@
-import type { Config } from "tailwindcss";
+import type { Config } from 'tailwindcss';
 
 const config: Config = {
   content: [
-    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
+    screens: {
+      md: '780px',
+      lg: '1280px',
+    },
+    colors: {
+      black: '#000000',
+      black_17: '#171717',
+      black_33: '#333236',
+      black_4b: '#4b4b4b',
+      gray_78: '#787486',
+      gray_9f: '#9fa6b2',
+      gray_d9: '#d9d9d9',
+      gray_ee: '#eeeeee',
+      gray_fa: '#fafafa',
+      white: '#ffffff',
+      violet: '#5534da',
+      violet_f1: '#f1effd',
+      red: '#D6173A',
+      green: '#7ac555',
+      purple: '#760dde',
+      orange: '#ffa500',
+      blue: '#76a5ea',
+      pink: '#e876ea',
+    },
     extend: {
       backgroundImage: {
-        "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
-        "gradient-conic":
-          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
+        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
+        'gradient-conic':
+          'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
       },
     },
   },


### PR DESCRIPTION
## 연관된 이슈
- #29 

## 작업 내용
- [x] 컬러 팔레트 설정
- [x] 반응형 브레이크 포인트 설정

## 스크린샷
<img width="194" alt="스크린샷 2024-06-21 오후 4 17 24" src="https://github.com/Part3-Team15/taskify/assets/108586797/89dcf51b-c886-467d-beee-fe0102bfbb5f">
<img width="169" alt="스크린샷 2024-06-21 오후 4 17 49" src="https://github.com/Part3-Team15/taskify/assets/108586797/ddb7e562-8912-4976-a0fd-59db8d75c165">

피그마에 위와 같이 적혀있는데
아래와 같이 사용하시면 됩니다.

<img width="232" alt="스크린샷 2024-06-21 오후 4 15 43" src="https://github.com/Part3-Team15/taskify/assets/108586797/a5aadbe5-1651-425c-943c-921436e0a94c">

<img width="231" alt="스크린샷 2024-06-21 오후 4 15 55" src="https://github.com/Part3-Team15/taskify/assets/108586797/b9bf3151-7987-47ab-9682-a4d070ea48e9">

tailwindCss는 기본적으로 모바일 디폴트라서
CSS 작업하실 때,
모바일 먼저 작업하시고
태블릿은 md (min width 780)
데스크탑은 lg (min width 1280)
붙이고 하시면 됩니다.

## 코멘트 및 논의 사항
브레이크 포인트는 일단 임의로 
**모바일** (779px 이하) 
**태블릿** (780px 이상 1279px 이하)
**데스크탑** (1280px 이상)
으로 설정해놨습니다. 
수정할 부분이나 여쭤볼 사항 있으면 리뷰 남겨주세요!

close #29 