### PR TITLE
✨ Feat: generateTagIndex 함수 구현

### DIFF
--- a/src/utils/generateTagIndex.ts
+++ b/src/utils/generateTagIndex.ts
@@ -1,0 +1,9 @@
+const NUM_TAG_COLORS = 16;
+
+const generateTagIndex = (tag: string) => {
+  const asciiList = tag.split('').map((c) => c.charCodeAt(0));
+  const sum = asciiList.reduce((a, b) => a + b, 0);
+  return sum % NUM_TAG_COLORS;
+};
+
+export default generateTagIndex;


### PR DESCRIPTION
## 연관된 이슈

- close #26 

## 작업 내용

- input: tag (string)
- output: index (number, 범위는 우리가 만들 태그 색상 개수, 현재는 16개)
- 내용: 글자들의 아스키 값 합을 색상 개수로 나눈 나머지를 인덱스로 하도록 구현했습니다.

### 스크린샷
<img height="100" alt="image" src="https://github.com/Part3-Team15/taskify/assets/24778465/3b40d7b2-4b6c-46af-b0e8-2afd38fe7dac">
<img height="100" alt="image" src="https://github.com/Part3-Team15/taskify/assets/24778465/e20adbf7-bd9e-4e7b-a45b-f9ced82fc2aa">

## 코멘트 및 논의 사항

- 해시 함수를 쓸 수 있지만, 추가로 라이브러리 사용해야 하는 것 같아서 아스키로 했습니다.
- <색상 개수>는 논의해서 지정하고, 컬러팔레트에서 tag-{idx}로 사용하면 좋을 것 같습니다.

- 만약 바로 hex 색상이 나왔으면 한다면, sha1 등으로 hash하고, 앞 6글자 이용하면 될 듯 합니다.
  - sha1 예시: string -> ecb252044b5ea0f679ee78ec1a12904739e2904d -> ecb252
  - 색이 예쁠지는 알 수 없지만 더 랜덤하게 이용 가능합니다.
