### PR TITLE
✨ Feat: 대시보드 전역 상태 관리

### DIFF
--- a/src/containers/mydashboard/DashBoards.tsx
+++ b/src/containers/mydashboard/DashBoards.tsx
@@ -1,0 +1,24 @@
+import { useSelector } from 'react-redux';
+
+import { useFetchDashboards } from '@/hooks/useFetchDashboards';
+import { RootState } from '@/store/store';
+
+const Dashboards = () => {
+  const { isLoading } = useFetchDashboards();
+  const dashboards = useSelector((state: RootState) => state.dashboards.dashboards);
+
+  if (isLoading) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h1>Dashboards</h1>
+      <ul>
+        {dashboards.map((dashboard) => (
+          <li key={dashboard.id}>{dashboard.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Dashboards;

--- a/src/hooks/useFetchDashboards.ts
+++ b/src/hooks/useFetchDashboards.ts
@@ -1,0 +1,35 @@
+import { useQuery } from 'react-query';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { setDashboards } from '@/store/reducers/dashboardsSlice';
+import { RootState } from '@/store/store';
+
+const fetchDashboards = async (accessToken: string) => {
+  const response = await fetch(
+    'https://sp-taskify-api.vercel.app/15/dashboards?navigationMethod=infiniteScroll&page=1&size=10',
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/json',
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch dashboards');
+  }
+
+  const data = await response.json();
+  return data;
+};
+
+export const useFetchDashboards = () => {
+  const dispatch = useDispatch();
+  const accessToken = useSelector((state: RootState) => state.user.accessToken); // 전역 상태에 저장된 user 정보에서 accessToken을 가져옴
+
+  return useQuery('dashboards', () => fetchDashboards(accessToken as string), {
+    onSuccess: (data) => {
+      dispatch(setDashboards({ dashboards: data.dashboards, totalCount: data.totalCount }));
+    },
+  });
+};

--- a/src/store/reducers/dashboardsSlice.ts
+++ b/src/store/reducers/dashboardsSlice.ts
@@ -1,0 +1,28 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { Dashboard } from '@/types/Dashboard.interface';
+
+interface DashboardsState {
+  dashboards: Dashboard[];
+  totalCount: number;
+}
+
+const initialState: DashboardsState = {
+  dashboards: [],
+  totalCount: 0,
+};
+
+const dashboardsSlice = createSlice({
+  name: 'dashboards',
+  initialState,
+  reducers: {
+    setDashboards(state, action: PayloadAction<{ dashboards: Dashboard[]; totalCount: number }>) {
+      state.dashboards = action.payload.dashboards;
+      state.totalCount = action.payload.totalCount;
+    },
+  },
+});
+
+export const { setDashboards } = dashboardsSlice.actions;
+
+export default dashboardsSlice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import { persistStore, persistReducer } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
 
+import dashboardsReducer from './reducers/dashboardsSlice';
 import userReducer from './reducers/userSlice';
 
 const persistConfig = {
@@ -14,6 +15,7 @@ const persistedReducer = persistReducer(persistConfig, userReducer);
 export const store = configureStore({
   reducer: {
     user: persistedReducer,
+    dashboards: dashboardsReducer,
   },
   devTools: process.env.NODE_ENV !== 'production',
 });

--- a/src/types/Dashboard.interface.ts
+++ b/src/types/Dashboard.interface.ts
@@ -1,0 +1,9 @@
+export interface Dashboard {
+  id: number;
+  title: string;
+  color: string;
+  userId: number;
+  createdAt: string;
+  updatedAt: string;
+  createdByMe: boolean;
+}


### PR DESCRIPTION
## 연관된 이슈

## 작업 내용
- [x] 로그인 후 받은 accessToken 수집
- [x] accessToken 인증을 통한 유저의 대시보드 목록 가져오기 (API 연동)
- [x] 대시보드 목록을 전역상태로 관리할 수 있음 (리듀서 생성 및 스토어에 저장)
- [x] 대시보드 목록 조회가 정상적으로 되는지 확인하기 위한 테스트 코드 

## 스크린샷
![image](https://github.com/Part3-Team15/taskify/assets/64190056/fac96f67-9ca9-45e6-9ba7-8641c87ad18a)


## 코멘트 및 논의 사항
/mydashboard 내의 대시보드 목록 조회, dashboard/id 내의 컬럼 목록 조회를 위해 dashboard id가 필요합니다.
따라서 대시보드 id값들(목록들)을 전역 상태로 관리하면 좋을 것 같아 러프하게 구현했습니다.
(이 PR은 머지되지 않아도 추후 대시보드 상태관리를 고민해야할 때 참고하면 좋을 것 같아 일단 정리해서 올립니다!)
