### PR TITLE
✨ feat: useFetchData 커스텀 훅

### DIFF
--- a/src/hooks/useFetchData.ts
+++ b/src/hooks/useFetchData.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect } from "react";
+import { useSelector } from "react-redux";
+import { RootState } from "@/store/store";
+
+const useFetchData = <T>(url: string) => {
+  const [data, setData] = useState<T | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const accessToken = useSelector((state: RootState) => state.user.accessToken);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const headers: HeadersInit = {};
+
+        if (accessToken) {
+          headers["Authorization"] = `Bearer ${accessToken}`; // 로그인 상태인 경우, 전역상태의 accessToken을 가져와 인증 요청을 할 수 있음
+        }
+
+        const response = await fetch(url, { headers });
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! Status: ${response.status}`);
+        }
+
+        const result: T = await response.json();
+        setData(result);
+      } catch (error) {
+        if (error instanceof Error) {
+          setError(error.message);
+        } else {
+          setError("An unknown error occurred");
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [url, accessToken]);
+
+  return { data, isLoading, error };
+};
+
+export default useFetchData;


### PR DESCRIPTION
## 연관된 이슈
- close #54 

## 작업 내용
- [x] accessToken 인증이 필요한 GET API 요청을 커스텀 훅으로 분리

### useFetchData 훅 설명
```ts
import { useState, useEffect } from 'react';
import { useSelector } from 'react-redux';
import { RootState } from '@/store/store';

const useFetchData = <T>(url: string) => {
  const [data, setData] = useState<T | null>(null); // 제네릭 변수 T : 리스폰스 데이터 타입을 임의로 지정할 수 있음
  const [isLoading, setIsLoading] = useState<boolean>(true);
  const [error, setError] = useState<string | null>(null);

  const accessToken = useSelector((state: RootState) => state.user.accessToken);

  useEffect(() => {
    const fetchData = async () => {
      try {
        const headers: HeadersInit = {};

        if (accessToken) {
          headers['Authorization'] = `Bearer ${accessToken}`; // 로그인 상태인 경우, 전역상태의 accessToken을 가져와 인증 요청을 할 수 있음
        }

        const response = await fetch(url, { headers });

        if (!response.ok) {
          throw new Error(`HTTP error! Status: ${response.status}`);
        }

        const result: T = await response.json();
        setData(result);
      } catch (error) {
        if (error instanceof Error) {
          setError(error.message);
        } else {
          setError('An unknown error occurred');
        }
      } finally {
        setIsLoading(false);
      }
    };

    fetchData();
  }, [url, accessToken]);

  return { data, isLoading, error };
};

export default useFetchData;
```
#### 파라미터
- `url` : Request URL
- `accessToken` : 전역상태에서 불러온 유저의 고유 토큰 (Optional)
- 제네릭 변수 `T` : 리턴값 `data`에 대한 타입 정의

#### 리턴값
- `data` : Response JSON 데이터
- `isLoading` : 비동기 로직 내의 로딩 상태. 로딩 스피너 등에 활용
- `error` : 에러 객체

## 스크린샷
커스텀 훅 사용 예시) 유저 대시보드의 컬럼 목록을 가져오고 싶을 때
![image](https://github.com/Part3-Team15/taskify/assets/64190056/fa91f7d6-da4f-4cb1-a308-0377c8f11244)


## 코멘트 및 논의 사항
GET API 호출할 때 accessToken 인증 요청이 계속 필요해서 커스텀 훅으로 분리해봤어요.!
