### PR TITLE
✨ Feat: user 관련 저장하는 정보 추가 (이메일, 프로필 이미지)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
     "plugin:import/recommended",
     "plugin:import/errors",
     "plugin:import/warnings",
+    "plugin:import/typescript",
     "plugin:react/recommended",
     "plugin:react/jsx-runtime",
     "plugin:@typescript-eslint/recommended",

--- a/src/hooks/useSignIn.ts
+++ b/src/hooks/useSignIn.ts
@@ -2,9 +2,10 @@ import { useMutation } from 'react-query';
 import { useDispatch } from 'react-redux';
 
 import { setUser, isLoading, setError } from '@/store/reducers/userSlice';
+import { User } from '@/types/User.interface';
 
 interface SignInResponse {
-  user: { nickname: string; id: number };
+  user: User;
   accessToken: string;
 }
 

--- a/src/store/reducers/userSlice.ts
+++ b/src/store/reducers/userSlice.ts
@@ -1,7 +1,9 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
+import { User } from '@/types/User.interface';
+
 interface UserState {
-  user: { nickname: string; id: number } | null;
+  user: User | null;
   accessToken: string | null;
   loading: boolean;
   error: string | null;
@@ -18,7 +20,7 @@ const userSlice = createSlice({
   name: 'user',
   initialState,
   reducers: {
-    setUser: (state, action: PayloadAction<{ user: { nickname: string; id: number }; accessToken: string }>) => {
+    setUser: (state, action: PayloadAction<{ user: User; accessToken: string }>) => {
       state.user = action.payload.user;
       state.accessToken = action.payload.accessToken;
     },

--- a/src/types/User.interface.ts
+++ b/src/types/User.interface.ts
@@ -1,0 +1,6 @@
+export interface User {
+  nickname: string;
+  id: number;
+  email: string;
+  profileImageUrl: string | null;
+}


### PR DESCRIPTION
## 연관된 이슈

- close #69

## 작업 내용

- User 타입 정의
- userSlice의 user에 정보 추가
- SigninResponse 에서 받는 정보도 추가
- .eslintrc.json에 import/typescript 플러그인 추가
