### PR TITLE
🎨 design(#31): 레이아웃 크기, 색상 수정

### DIFF
--- a/src/containers/dashboard/ColumnsSection.tsx
+++ b/src/containers/dashboard/ColumnsSection.tsx
@@ -26,8 +26,8 @@ export default function ColumnsSection({ id }: ColumnsSectionProps) {
   }
 
   return (
-    <section className='block bg-gray-fa lg:flex'>
-      <ul className='block bg-gray-fa lg:flex'>
+    <section className='block lg:flex'>
+      <ul className='block lg:flex'>
         {columns?.data && columns.data.map((column) => <Column key={column.id} column={column} />)}
       </ul>
 

--- a/src/containers/mydashboard/index.tsx
+++ b/src/containers/mydashboard/index.tsx
@@ -2,7 +2,7 @@ import DashboardList from './DashboardList';
 
 export default function MyDashboard() {
   return (
-    <div className='h-dvh bg-gray-fa p-10'>
+    <div className='h-dvh p-10'>
       <DashboardList />
     </div>
   );

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -9,24 +9,24 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
 
   if (currentPath === '/') {
     return (
-      <>
+      <div className='min-w-[360px]'>
         <Header />
         {children}
-      </>
+      </div>
     );
   }
 
   const isDisabled = currentPath === '/signin' || currentPath === '/signup' || currentPath === '/404';
 
-  if (isDisabled) return <>{children}</>;
+  if (isDisabled) return <div className='min-w-[360px]'>{children}</div>;
 
   return (
-    <div className='flex max-h-dvh max-w-screen-lg'>
+    <div className='flex min-w-[360px]'>
       <Sidebar />
 
       <div className='flex grow flex-col'>
         <Header />
-        <main className='flex flex-col overflow-y-scroll'>{children}</main>
+        <main className='flex flex-col overflow-y-scroll bg-gray-fa'>{children}</main>
       </div>
     </div>
   );


### PR DESCRIPTION
## 연관된 이슈

- #31

## 작업 내용

- 최대 크기 없앰
- 최소 너비 375px로 설정
- main 부분 배경색 지정 (페이지별로 각각 지정하던 것 삭제)

## 스크린샷
<img width="1440" alt="image" src="https://github.com/Part3-Team15/taskify/assets/24778465/eacd259c-026c-4463-b490-f1aabde52249">
<img width="971" alt="image" src="https://github.com/Part3-Team15/taskify/assets/24778465/817cb98c-5678-4b13-99f1-aa1ee1337115">
<img width="983" alt="image" src="https://github.com/Part3-Team15/taskify/assets/24778465/766c555d-28cc-407e-8744-489ad00b1adc">


## 코멘트 및 논의 사항

- 레이아웃에서 최대 크기 지정할 필요가 없는 것 같아서 삭제했습니다. (피그마에서 늘어나면 헤더는 계속 늘어남)
- 각자 섹션 크기가 고정된다면 내부에서 고정하면 될 것 같습니다.
- 배경색상을 레이아웃에서 지정해서 각 페이지에 있는 배경색 삭제했습니다.
