### PR TITLE
🎨 design(#31): 레이아웃 main이 남은 크기 차지하도록 설정

### DIFF
--- a/src/containers/mydashboard/index.tsx
+++ b/src/containers/mydashboard/index.tsx
@@ -2,7 +2,7 @@ import DashboardList from './DashboardList';
 
 export default function MyDashboard() {
   return (
-    <div className='h-dvh p-10'>
+    <div className='p-10'>
       <DashboardList />
     </div>
   );

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -21,12 +21,12 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
   if (isDisabled) return <div className='min-w-[360px]'>{children}</div>;
 
   return (
-    <div className='flex min-w-[360px]'>
+    <div className='flex min-h-lvh min-w-[360px]'>
       <Sidebar />
 
       <div className='flex grow flex-col'>
         <Header />
-        <main className='flex flex-col overflow-y-scroll bg-gray-fa'>{children}</main>
+        <main className='flex grow flex-col overflow-y-scroll bg-gray-fa'>{children}</main>
       </div>
     </div>
   );


### PR DESCRIPTION
## 연관된 이슈

- #31

## 작업 내용

- [x] MainLayout에서 main이 남은 높이를 모두 차지하도록 변경
- [x] mydashboard에서 중복으로 적용된 부분 제외

## 스크린샷
<img width="400" alt="image" src="https://github.com/Part3-Team15/taskify/assets/24778465/64e5ef06-e883-4240-b8a5-f4d0912f6b4e">
<img width="400" alt="image" src="https://github.com/Part3-Team15/taskify/assets/24778465/9a27a0e0-ff5e-42bd-b0c0-4b9136cdfaee">


<img width="600" alt="image" src="https://github.com/Part3-Team15/taskify/assets/24778465/c115040c-f57d-4503-837c-3cc00e2d7890">

## 코멘트 및 논의 사항

- 다른 페이지에서는 이상없고, 대시보드 상세페이지에서 스크롤이 생깁니다.
