### PR TITLE
🎨 design(#129): 화면 세로 크기를 줄이면 레이아웃이 고장나는 버그 수정

### DIFF
--- a/src/components/Sidebar/DashboardItem.tsx
+++ b/src/components/Sidebar/DashboardItem.tsx
@@ -19,7 +19,7 @@ export default function DashboardItem({ dashboard, nowDashboard }: DashboardItem
         className={`${itemClasses} flex items-center justify-center rounded-md py-3 hover:bg-violet/20 md:justify-start md:px-3`}
       >
         <div className='rounded-full p-1' style={{ backgroundColor: dashboard.color }} />
-        <p className='hidden pl-4 pr-[6px] text-lg font-medium md:block'>{dashboard.title}</p>
+        <p className='hidden overflow-hidden pl-4 pr-[6px] text-lg font-medium md:block'>{dashboard.title}</p>
         {dashboard.createdByMe && (
           <Image src={'/icons/crown.svg'} alt='my' className='hidden md:block' width={18} height={14} />
         )}

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -3,6 +3,8 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 
+import NavButton from '../Button/NavButton';
+
 import DashboardItem from './DashboardItem';
 
 import useFetchData from '@/hooks/useFetchData';
@@ -39,7 +41,7 @@ export default function Sidebar() {
   };
 
   return (
-    <aside className='flex h-screen min-w-16 flex-col border-r border-gray-d9 px-3 py-5 md:min-w-40 lg:min-w-72'>
+    <aside className='flex min-w-16 flex-col border-r border-gray-d9 px-3 py-5 md:min-w-40 lg:min-w-72'>
       <Link href='/' className='flex items-center justify-center pb-14 md:block md:px-3'>
         <div className='relative hidden h-[33px] w-[110px] md:block'>
           <Image src={'/icons/logo.svg'} alt='logo' priority className='' fill />
@@ -49,10 +51,9 @@ export default function Sidebar() {
         </div>
       </Link>
 
-      <div className='flex flex-col gap-2 md:min-h-[790px]'>
+      <div className='flex flex-col gap-2'>
         <div className='flex items-center justify-center md:justify-between'>
           <p className='hidden px-3 text-xs font-bold text-gray-78 md:block'>Dashboards</p>
-
           <button
             className='p-3'
             onClick={() => {
@@ -86,7 +87,7 @@ export default function Sidebar() {
         <div className='m-2 border-b border-gray-d9' />
 
         {isLoading ? (
-          <ul className='flex animate-pulse flex-col gap-2'>
+          <ul className='flex animate-pulse flex-col gap-2 overflow-y-auto scrollbar-hide md:max-h-[52dvh] md:min-h-[290px]'>
             {[...Array(10)].map((_, i) => (
               <li
                 key={i}
@@ -95,36 +96,17 @@ export default function Sidebar() {
             ))}
           </ul>
         ) : (
-          <ul className='flex flex-col gap-2'>
+          <ul className='flex flex-col gap-2 overflow-y-auto scrollbar-hide md:max-h-[52dvh] md:min-h-[290px]'>
             {data?.dashboards.map((dashboard) => (
               <DashboardItem key={dashboard.id} dashboard={dashboard} nowDashboard={Number(id)} />
             ))}
           </ul>
         )}
-      </div>
-
-      <div className='flex flex-col items-center pt-3 md:flex-row'>
-        <NavButton direction='left' onClick={handlePrev} isDisable={page === 1} />
-        <NavButton direction='right' onClick={handleNext} isDisable={page === totalPage} />
+        <div className='flex flex-col items-center pt-3 md:flex-row'>
+          <NavButton direction='left' onClick={handlePrev} isDisable={page === 1} />
+          <NavButton direction='right' onClick={handleNext} isDisable={page === totalPage} />
+        </div>
       </div>
     </aside>
   );
 }
-
-interface NavButtonProps {
-  direction: 'left' | 'right';
-  onClick: () => void;
-  isDisable?: boolean;
-}
-
-const NavButton = ({ direction, onClick, isDisable }: NavButtonProps) => (
-  <button
-    className={`btn-white rounded-none ${direction === 'left' ? 'rounded-s-[4px]' : 'rounded-e-[4px]'} size-10`}
-    onClick={onClick}
-    disabled={isDisable}
-  >
-    <div className={`${direction === 'left' ? 'rotate-180' : ''} relative h-[12px] w-[8px]`}>
-      <Image src={'/icons/arrow-white.svg'} alt={`arrow-${direction}`} fill />
-    </div>
-  </button>
-);

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -44,7 +44,7 @@ export default function Sidebar() {
   };
 
   return (
-    <aside className='flex min-w-16 flex-col border-r border-gray-d9 px-3 py-5 md:min-w-40 lg:min-w-72'>
+    <aside className='flex min-w-16 max-w-[300px] flex-col border-r border-gray-d9 px-3 py-5 md:min-w-40 lg:min-w-72'>
       <Link href={user ? '/mydashboard' : '/'} className='flex items-center justify-center pb-14 md:block md:px-3'>
         <div className='relative hidden h-[33px] w-[110px] md:block'>
           <Image src={'/icons/logo.svg'} alt='logo' priority className='' fill />
@@ -99,16 +99,23 @@ export default function Sidebar() {
             ))}
           </ul>
         ) : (
-          <ul className='flex h-min flex-col gap-2'>
-            {data?.dashboards.map((dashboard) => (
-              <DashboardItem key={dashboard.id} dashboard={dashboard} nowDashboard={Number(id)} />
-            ))}
-          </ul>
+          <>
+            <ul className='flex h-min flex-col gap-2'>
+              {data?.dashboards.map((dashboard) => (
+                <DashboardItem key={dashboard.id} dashboard={dashboard} nowDashboard={Number(id)} />
+              ))}
+            </ul>
+
+            {totalPage > 1 ? (
+              <div className='flex flex-col items-center pt-3 md:flex-row'>
+                <NavButton direction='left' onClick={handlePrev} isDisable={page === 1} />
+                <NavButton direction='right' onClick={handleNext} isDisable={page === totalPage} />
+              </div>
+            ) : (
+              <></>
+            )}
+          </>
         )}
-        <div className='flex flex-col items-center pt-3 md:flex-row'>
-          <NavButton direction='left' onClick={handlePrev} isDisable={page === 1} />
-          <NavButton direction='right' onClick={handleNext} isDisable={page === totalPage} />
-        </div>
       </div>
     </aside>
   );

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
+import { useSelector } from 'react-redux';
 
 import NavButton from '../Button/NavButton';
 
@@ -10,9 +11,11 @@ import DashboardItem from './DashboardItem';
 import useFetchData from '@/hooks/useFetchData';
 import useModal from '@/hooks/useModal';
 import { getDashboardsList } from '@/services/getService';
+import { RootState } from '@/store/store';
 import { DashboardsResponse } from '@/types/Dashboard.interface';
 
 export default function Sidebar() {
+  const { user } = useSelector((state: RootState) => state.user);
   const router = useRouter();
   const { id } = router.query;
   const [page, setPage] = useState<number>(1);
@@ -42,7 +45,7 @@ export default function Sidebar() {
 
   return (
     <aside className='flex min-w-16 flex-col border-r border-gray-d9 px-3 py-5 md:min-w-40 lg:min-w-72'>
-      <Link href='/' className='flex items-center justify-center pb-14 md:block md:px-3'>
+      <Link href={user ? '/mydashboard' : '/'} className='flex items-center justify-center pb-14 md:block md:px-3'>
         <div className='relative hidden h-[33px] w-[110px] md:block'>
           <Image src={'/icons/logo.svg'} alt='logo' priority className='' fill />
         </div>
@@ -51,7 +54,7 @@ export default function Sidebar() {
         </div>
       </Link>
 
-      <div className='flex flex-col gap-2'>
+      <div className='flex grow flex-col gap-2'>
         <div className='flex items-center justify-center md:justify-between'>
           <p className='hidden px-3 text-xs font-bold text-gray-78 md:block'>Dashboards</p>
           <button
@@ -87,7 +90,7 @@ export default function Sidebar() {
         <div className='m-2 border-b border-gray-d9' />
 
         {isLoading ? (
-          <ul className='flex animate-pulse flex-col gap-2 overflow-y-auto scrollbar-hide md:max-h-[52dvh] md:min-h-[290px]'>
+          <ul className='flex h-min animate-pulse flex-col gap-2'>
             {[...Array(10)].map((_, i) => (
               <li
                 key={i}
@@ -96,7 +99,7 @@ export default function Sidebar() {
             ))}
           </ul>
         ) : (
-          <ul className='flex flex-col gap-2 overflow-y-auto scrollbar-hide md:max-h-[52dvh] md:min-h-[290px]'>
+          <ul className='flex h-min flex-col gap-2'>
             {data?.dashboards.map((dashboard) => (
               <DashboardItem key={dashboard.id} dashboard={dashboard} nowDashboard={Number(id)} />
             ))}

--- a/src/containers/mydashboard/DashboardList/index.tsx
+++ b/src/containers/mydashboard/DashboardList/index.tsx
@@ -41,9 +41,9 @@ export default function DashboardList() {
   };
 
   return (
-    <section className='w-max'>
-      <ul className='grid grid-rows-1 gap-3 pb-3 font-semibold text-black-33 md:min-h-[216px] md:grid-cols-2 md:grid-rows-3 lg:min-h-[140px] lg:grid-cols-3 lg:grid-rows-2'>
-        <li className='h-16 w-64 rounded-lg border border-gray-d9 bg-white md:w-60 lg:w-80'>
+    <section className='w-max grow flex-col justify-between'>
+      <ul className='grid grid-rows-1 gap-3 font-semibold text-black-33 md:min-h-[216px] md:grid-cols-2 md:grid-rows-3 lg:min-h-[140px] lg:grid-cols-3 lg:grid-rows-2'>
+        <li className='h-12 w-64 rounded-lg border border-gray-d9 bg-white md:h-16 md:w-60 lg:w-[300px]'>
           <button className='btn-violet-light size-full gap-4'>
             새로운 대시보드
             <Image src={'/icons/plus-filled.svg'} alt='plus' width={22} height={22} />
@@ -52,13 +52,19 @@ export default function DashboardList() {
         {isLoading ? (
           <>
             {[...Array(5)].map((_, i) => (
-              <li key={i} className='h-16 w-64 rounded-lg border border-gray-d9 bg-white md:w-60 lg:w-[300px]' />
+              <li
+                key={i}
+                className='h-12 w-64 animate-pulse rounded-lg border border-gray-d9 bg-gray-fa md:h-16 md:w-60 lg:w-[300px]'
+              />
             ))}
           </>
         ) : (
           <>
             {dashboardResponse?.dashboards.map((dashboard) => (
-              <li className='h-16 w-64 rounded-lg border border-gray-d9 bg-white md:w-60 lg:w-80' key={dashboard.id}>
+              <li
+                className='h-12 w-64 rounded-lg border border-gray-d9 bg-white md:h-16 md:w-60 lg:w-[300px]'
+                key={dashboard.id}
+              >
                 <Link href={`/dashboard/${dashboard.id}`} className={'btn-violet-light size-full rounded-md px-5'}>
                   <div className='flex size-full items-center'>
                     <div className='rounded-full p-1' style={{ backgroundColor: dashboard.color }} />
@@ -71,9 +77,16 @@ export default function DashboardList() {
             ))}
           </>
         )}
-      </ul>
 
-      <Pagination currentChunk={currentChunk} totalPage={totalPage} onNextClick={handleNext} onPrevClick={handlePrev} />
+        <div className='md:col-span-2 lg:col-span-3'>
+          <Pagination
+            currentChunk={currentChunk}
+            totalPage={totalPage}
+            onNextClick={handleNext}
+            onPrevClick={handlePrev}
+          />
+        </div>
+      </ul>
     </section>
   );
 }

--- a/src/containers/mydashboard/DashboardList/index.tsx
+++ b/src/containers/mydashboard/DashboardList/index.tsx
@@ -68,9 +68,11 @@ export default function DashboardList() {
                 <Link href={`/dashboard/${dashboard.id}`} className={'btn-violet-light size-full rounded-md px-5'}>
                   <div className='flex size-full items-center'>
                     <div className='rounded-full p-1' style={{ backgroundColor: dashboard.color }} />
-                    <p className='h-[28px] max-w-[150px] overflow-hidden pl-4 pr-1 text-lg font-medium lg:max-w-[200px]'>
-                      {dashboard.title}
-                    </p>
+                    <div className='h-[28px] max-w-[150px] overflow-hidden pl-4 pr-1 text-lg font-medium lg:max-w-[200px]'>
+                      <p className={`${dashboard.title.length > 9 ? 'hover:animate-scroll-horizontal' : ''}`}>
+                        {dashboard.title}
+                      </p>
+                    </div>
                     {dashboard.createdByMe && <Image src={'/icons/crown.svg'} alt='my' width={20} height={16} />}
                   </div>
                   <Image src={'/icons/arrow-black.svg'} alt='arrow' width={14} height={14} />

--- a/src/containers/mydashboard/DashboardList/index.tsx
+++ b/src/containers/mydashboard/DashboardList/index.tsx
@@ -42,7 +42,7 @@ export default function DashboardList() {
 
   return (
     <section className='w-max grow flex-col justify-between'>
-      <ul className='grid grid-rows-1 gap-3 font-semibold text-black-33 md:min-h-[216px] md:grid-cols-2 md:grid-rows-3 lg:min-h-[140px] lg:grid-cols-3 lg:grid-rows-2'>
+      <ul className='grid grid-rows-1 gap-3 font-semibold text-black-33 md:min-h-[216px] md:grid-cols-2 md:grid-rows-3 lg:min-h-[140px] lg:grid-cols-3'>
         <li className='h-12 w-64 rounded-lg border border-gray-d9 bg-white md:h-16 md:w-60 lg:w-[300px]'>
           <button className='btn-violet-light size-full gap-4'>
             새로운 대시보드
@@ -68,7 +68,9 @@ export default function DashboardList() {
                 <Link href={`/dashboard/${dashboard.id}`} className={'btn-violet-light size-full rounded-md px-5'}>
                   <div className='flex size-full items-center'>
                     <div className='rounded-full p-1' style={{ backgroundColor: dashboard.color }} />
-                    <p className='pl-4 pr-1 text-lg font-medium'>{dashboard.title}</p>
+                    <p className='h-[28px] max-w-[150px] overflow-hidden pl-4 pr-1 text-lg font-medium lg:max-w-[200px]'>
+                      {dashboard.title}
+                    </p>
                     {dashboard.createdByMe && <Image src={'/icons/crown.svg'} alt='my' width={20} height={16} />}
                   </div>
                   <Image src={'/icons/arrow-black.svg'} alt='arrow' width={14} height={14} />
@@ -78,7 +80,7 @@ export default function DashboardList() {
           </>
         )}
 
-        <div className='md:col-span-2 lg:col-span-3'>
+        <div className='md:col-span-2 lg:col-span-3 lg:row-start-3'>
           <Pagination
             currentChunk={currentChunk}
             totalPage={totalPage}

--- a/src/containers/mydashboard/InvitedDashboardList/index.tsx
+++ b/src/containers/mydashboard/InvitedDashboardList/index.tsx
@@ -101,7 +101,7 @@ export default function InvitedDashboardList() {
 
   if (error) {
     return (
-      <section className='max-h-[calc(100vh-610px)] min-h-80 grow overflow-hidden rounded-lg border-0 bg-white md:max-h-[calc(100vh-390px)]'>
+      <section className='max-h-[calc(100vh-610px)] min-h-[580px] grow overflow-hidden rounded-lg border-0 bg-white md:max-h-[calc(100vh-390px)]'>
         <p className='px-7 pb-5 pt-8 text-base font-bold text-black-33'>초대받은 대시보드</p>
         <div className='flex items-center justify-center'>
           <p>데이터를 가져오는 중 오류가 발생했습니다.</p>
@@ -112,7 +112,7 @@ export default function InvitedDashboardList() {
   }
 
   return (
-    <section className='max-h-[calc(100vh-610px)] min-h-80 grow overflow-hidden rounded-lg border-0 bg-white md:max-h-[calc(100vh-390px)]'>
+    <section className='max-h-[calc(100vh-610px)] min-h-[580px] grow overflow-hidden rounded-lg border-0 bg-white md:max-h-[calc(100vh-390px)]'>
       <p className='px-7 pb-5 pt-8 text-base font-bold text-black-33'>초대받은 대시보드</p>
       {isLoading ? (
         <div className='flex animate-pulse flex-col'>

--- a/src/containers/mydashboard/InvitedDashboardList/index.tsx
+++ b/src/containers/mydashboard/InvitedDashboardList/index.tsx
@@ -112,7 +112,7 @@ export default function InvitedDashboardList() {
   }
 
   return (
-    <section className='max-h-[calc(100vh-610px)] min-h-[580px] grow overflow-hidden rounded-lg border-0 bg-white md:max-h-[calc(100vh-390px)]'>
+    <section className='h-dvh max-h-[calc(100vh-590px)] min-h-[400px] grow overflow-hidden rounded-lg border-0 bg-white md:max-h-[calc(100dvh-465px)] lg:max-h-[calc(100dvh-410px)]'>
       <p className='px-7 pb-5 pt-8 text-base font-bold text-black-33'>초대받은 대시보드</p>
       {isLoading ? (
         <div className='flex animate-pulse flex-col'>

--- a/src/containers/mydashboard/InvitedDashboardList/index.tsx
+++ b/src/containers/mydashboard/InvitedDashboardList/index.tsx
@@ -101,18 +101,18 @@ export default function InvitedDashboardList() {
 
   if (error) {
     return (
-      <div className='h-full max-w-screen-lg overflow-hidden rounded-lg border-0 bg-white'>
+      <section className='max-h-[calc(100vh-610px)] min-h-80 grow overflow-hidden rounded-lg border-0 bg-white md:max-h-[calc(100vh-390px)]'>
         <p className='px-7 pb-5 pt-8 text-base font-bold text-black-33'>초대받은 대시보드</p>
         <div className='flex items-center justify-center'>
           <p>데이터를 가져오는 중 오류가 발생했습니다.</p>
           <p>{error.message}</p>
         </div>
-      </div>
+      </section>
     );
   }
 
   return (
-    <section className='h-full min-h-80 overflow-hidden rounded-lg border-0 bg-white'>
+    <section className='max-h-[calc(100vh-610px)] min-h-80 grow overflow-hidden rounded-lg border-0 bg-white md:max-h-[calc(100vh-390px)]'>
       <p className='px-7 pb-5 pt-8 text-base font-bold text-black-33'>초대받은 대시보드</p>
       {isLoading ? (
         <div className='flex animate-pulse flex-col'>
@@ -140,8 +140,6 @@ export default function InvitedDashboardList() {
                   ))}
                 </div>
               ))}
-
-              <div ref={observerRef} className='h-1' />
             </div>
           </div>
         </div>

--- a/src/containers/mydashboard/index.tsx
+++ b/src/containers/mydashboard/index.tsx
@@ -3,7 +3,7 @@ import InvitedDashboardList from './InvitedDashboardList';
 
 export default function MyDashboard() {
   return (
-    <div className='flex size-full max-w-min flex-col gap-11 bg-gray-fa p-10 md:max-h-[calc(100vh-70px)]'>
+    <div className='flex w-full max-w-min flex-col gap-11 bg-gray-fa p-10'>
       <DashboardList />
       <InvitedDashboardList />
     </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -84,6 +84,15 @@ const config: Config = {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
       },
+      animation: {
+        'scroll-horizontal': 'scroll-horizontal 20s linear infinite',
+      },
+      keyframes: {
+        'scroll-horizontal': {
+          '0%': { transform: 'translateX(0%)' },
+          '100%': { transform: 'translateX(-100%)' },
+        },
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
## 연관된 이슈

- close #129 

## 작업 내용

윈도우창 세로 크기를 줄이면 밑에 공간이 비어버리는 문제가 있어서 해결했습니다

- [x] 레이아웃 세로 방향 버그 수정

## 스크린샷

![Screenshot 2024-06-30 at 13 32 03](https://github.com/Part3-Team15/taskify/assets/89517903/24056387-1307-4bbc-8d5c-563f84fbc520)
![Screenshot 2024-06-30 at 13 29 39](https://github.com/Part3-Team15/taskify/assets/89517903/d16de3bc-ffcb-4118-8f7a-e418a33b01e4)


## 코멘트 및 논의 사항

사이드바에 스크롤을 넣었는데 스크롤바 생긴게 별로여서 tailwind-scrollbar-hide 플러그인 사용해서 숨겼습니다 있는게 더 나을까요?
