### PR TITLE
✨ feat(#40): 대시보드 수정페이지 완성

### DIFF
--- a/src/components/Header/DashboardHeader/index.tsx
+++ b/src/components/Header/DashboardHeader/index.tsx
@@ -33,7 +33,7 @@ export default function DashboardHeader() {
   const { id: dashboardId, title, createdByMe } = dashboard;
 
   return (
-    <header className='flex h-[70px] w-full items-center justify-end border-b border-gray-d9 bg-white px-[24px] text-black-33 md:px-[40px] lg:justify-between'>
+    <header className='flex h-[60px] w-full items-center justify-end border-b border-gray-d9 bg-white px-[24px] text-black-33 md:h-[70px] md:px-[40px] lg:justify-between'>
       <div className='hidden items-center gap-2 lg:flex'>
         <h1 className='text-xl font-bold'>{title}</h1>
         {createdByMe && <Image src='/icons/crown.svg' alt='왕관 아이콘' width={20} height={16} />}

--- a/src/components/Header/DefaultHeader.tsx
+++ b/src/components/Header/DefaultHeader.tsx
@@ -6,7 +6,7 @@ interface DefaultHeaderProps {
 
 export default function DefaultHeader({ title }: DefaultHeaderProps) {
   return (
-    <header className='flex h-[70px] w-full items-center justify-between border-b border-gray-d9 bg-white px-[24px] text-black-33 md:px-[40px]'>
+    <header className='flex h-[60px] w-full items-center justify-between border-b border-gray-d9 bg-white px-[24px] text-black-33 md:h-[70px] md:px-[40px]'>
       <h1 className='text-lg font-bold md:text-xl'>{title}</h1>
       <UserMenuDropdown />
     </header>

--- a/src/components/Header/LandingHeader.tsx
+++ b/src/components/Header/LandingHeader.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 
 export default function LandingHeader() {
   return (
-    <header className='flex h-[70px] w-full items-center justify-between bg-black px-[24px]'>
+    <header className='flex h-[60px] w-full items-center justify-between bg-black px-[24px] md:h-[70px]'>
       <Link href='/'>
         <Image className='md:hidden' src='/icons/logo-white-s.svg' alt='로고' width={24} height={27} priority />
         <Image className='hidden md:block' src='/icons/logo-white.svg' alt='로고' width={121} height={39} priority />

--- a/src/containers/dashboard/edit/DashboardEdit.tsx
+++ b/src/containers/dashboard/edit/DashboardEdit.tsx
@@ -1,0 +1,41 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+import InvitedMembersSection from './InvitedMembersSection';
+import MembersSection from './MembersSection';
+
+export default function DashboardEdit() {
+  const router = useRouter();
+  const { id } = router.query;
+
+  const handleDeleteClick = () => {
+    alert('대시보드 삭제');
+  };
+
+  return (
+    <div className='px-3 py-4 text-black-33 md:p-5'>
+      <Link
+        href={`/dashboard/${id}`}
+        className='mb-5 flex items-center gap-1.5 text-sm font-medium md:mb-6 md:text-base'
+      >
+        <div className='relative size-[18px] rotate-180 md:size-5'>
+          <Image src='/icons/arrow-black.svg' alt='뒤로가기 아이콘' fill />
+        </div>
+        돌아가기
+      </Link>
+      <div className='flex flex-col gap-4'>
+        {/* 대시보드 수정 */}
+        <MembersSection />
+        <InvitedMembersSection />
+      </div>
+      <button
+        type='button'
+        className='btn-gray gray-border my-8 size-fit rounded-lg px-[84px] py-4 text-base font-medium md:my-12 md:px-[95px] md:py-5 md:text-lg'
+        onClick={handleDeleteClick}
+      >
+        대시보드 삭제하기
+      </button>
+    </div>
+  );
+}

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -21,7 +21,7 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
   if (isDisabled) return <div className='min-w-[360px]'>{children}</div>;
 
   return (
-    <div className='flex min-w-[360px]'>
+    <div className='flex min-w-[375px]'>
       <Sidebar />
 
       <div className='flex grow flex-col'>

--- a/src/pages/dashboard/[id]/edit.tsx
+++ b/src/pages/dashboard/[id]/edit.tsx
@@ -1,14 +1,5 @@
-import InvitedMembersSection from '@/containers/dashboard/edit/InvitedMembersSection';
-import MembersSection from '@/containers/dashboard/edit/MembersSection';
+import DashboardEdit from '@/containers/dashboard/edit/DashboardEdit';
 
 export default function DashboardEditPage() {
-  return (
-    <div className='flex flex-col gap-4 px-3 py-4 text-black-33 md:p-5'>
-      {/* 돌아가기 */}
-      {/* 대시보드 수정 */}
-      <MembersSection />
-      <InvitedMembersSection />
-      {/* 대시보드 삭제 버튼 */}
-    </div>
-  );
+  return <DashboardEdit />;
 }


### PR DESCRIPTION
## 연관된 이슈

- close #40

## 작업 내용

- [x] 뒤로가기 버튼
- [x] 대시보드 삭제 버튼

틈새작업
- [x] 헤더 모바일 높이가 달라서 수정
- [x] 페이지 최소크기 360px -> 375px (375 한다하고 360 해놨네요..)

## 스크린샷
<img width="402" alt="image" src="https://github.com/Part3-Team15/taskify/assets/24778465/d6a11eb4-e21a-4c7d-8742-11b6cf70f2f9">

## 코멘트 및 논의 사항

- 나머지 내용 컴포넌트만 추가하면 됩니다!
- 자잘한 버튼/링크 때문에 페이지가 길고 더러워질 것 같아서, 페이지 내용을 컴포넌트로 뺐습니다.
- 모달 연결은 리팩토링 이후 한번에 작업하려고 합니다!