### PR TITLE
🛠  Fix(#77): 재요청 횟수 제한

### DIFF
--- a/src/hooks/useFetchData.ts
+++ b/src/hooks/useFetchData.ts
@@ -12,6 +12,7 @@ const useFetchData = <T>(queryKey: QueryKey, getService: () => Promise<{ data: T
         throw new Error('데이터를 불러오는 중 에러 발생: ' + error);
       }
     },
+    retry: 1,
   });
 };
 


### PR DESCRIPTION
## 연관된 이슈

- close #77

## 작업 내용

- 잘못된 요청을 보내도 무한히 재요청 보내지 않게 횟수 제한했습니다.

## 스크린샷

https://github.com/Part3-Team15/taskify/assets/24778465/566e6eda-d8a1-4510-b4f3-236f2bd64cd5

https://github.com/Part3-Team15/taskify/assets/24778465/cdf0f3bf-6e2e-49b7-b8f0-8eaaa009f2c8


## 코멘트 및 논의 사항

- 위에가 1회, 아래가 3회 재요청 제한을 건 모습입니다.
3회는 시간이 좀 오래걸려서 재요청 간격을 줄이거나 횟수를 줄이는 게 좋을 것 같습니다!
저는 1회여도 괜찮다고 보는데 다른 분들은 어떠신가요??
- 일단은 get에만 재요청 제한을 걸었습니다. 다른 요청은 큰 문제가 없었던 것 같아서요! (아마도 에러 핸들링을 해서..?)
