### PR TITLE
🛠  fix(#185): 대시보드 이름 수정 시 15자 길이 제한

### DIFF
--- a/src/containers/dashboard/edit/DashboardModifySection.tsx
+++ b/src/containers/dashboard/edit/DashboardModifySection.tsx
@@ -16,6 +16,7 @@ export default function DashboardModifySection() {
   const { id } = router.query;
   const { openNotificationModal } = useModal();
   const queryClient = useQueryClient();
+  const [errorMessage, setErrorMessage] = useState('');
 
   const [value, setValue] = useState<DashboardInfoState>({
     title: '',
@@ -76,6 +77,16 @@ export default function DashboardModifySection() {
     }));
   };
 
+  const handleValidCheck = () => {
+    if (!value.title) {
+      setErrorMessage('이름을 입력해주세요.');
+    } else if (value.title.length > 15) {
+      setErrorMessage('15자 이내로 입력해주세요');
+    } else {
+      setErrorMessage('');
+    }
+  };
+
   if (isLoading) {
     return <section className='section h-[211px] animate-pulse bg-gray-f5 px-[18px] py-[32px] md:h-[256px]'></section>;
   }
@@ -106,12 +117,14 @@ export default function DashboardModifySection() {
             type='text'
             value={value.title}
             placeholder='대시보드 이름을 입력해 주세요'
+            onBlur={handleValidCheck}
             onChange={(e) => setValue((prevValue) => ({ ...prevValue, title: e.target.value }))}
           />
+          {errorMessage && <p className='mt-2 text-sm text-red'>{errorMessage}</p>}
         </div>
       </main>
       <footer className='flex justify-end'>
-        <ActionButton onClick={handleModifyButton} disabled={isButtonDisabled}>
+        <ActionButton onClick={handleModifyButton} disabled={isButtonDisabled || !!errorMessage}>
           변경
         </ActionButton>
       </footer>

--- a/src/containers/signin&signup/SignUpForm.tsx
+++ b/src/containers/signin&signup/SignUpForm.tsx
@@ -20,7 +20,7 @@ export type TSignUpInputs = {
 
 const schema = yup.object().shape({
   email: yup.string().email('유효한 이메일 주소를 입력해주세요.').required('이메일을 입력해주세요.'),
-  nickname: yup.string().required('닉네임을 입력해주세요.'),
+  nickname: yup.string().required('닉네임을 입력해주세요.').max(10, '닉네임은 최대 10자까지 가능합니다.'),
   password: yup.string().required('비밀번호를 입력해주세요.').min(8, '비밀번호는 최소 8자 이상이어야 합니다.'),
   passwordConfirmation: yup
     .string()


### PR DESCRIPTION
## 연관된 이슈

- close #185 

## 작업 내용

대시보드 생성 모달 코드이용해서
대시보드 관리에서 대시보드 이름 수정 시 15자 제한과 내용을 꼭 입력하도록 수정했습니다

