### PR TITLE
🛠  fix(#168): 대시보드 초대 알림 문제 해결

### DIFF
--- a/src/components/InviteNotice/index.tsx
+++ b/src/components/InviteNotice/index.tsx
@@ -1,13 +1,19 @@
 import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { toast, ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
 import { TOAST_DEFAULT_SETTING } from '@/constants';
 import useFetchData from '@/hooks/useFetchData';
 import { getInvitationsList } from '@/services/getService';
+import { RootState } from '@/store/store';
 import { Invitation, InvitationsResponse } from '@/types/Invitation.interface';
 
 export default function InvitationNotice() {
+  const { user } = useSelector((state: RootState) => state.user);
+
+  if (!user) return null;
+
   // NOTE: 3초마다 refetch 하도록 설정
   const { data } = useFetchData<InvitationsResponse>(['invitations', 'notice'], () => getInvitationsList(), 5000);
   const [savedInvitations, setSavedInvitations] = useState<Invitation[]>(data?.invitations || []);


### PR DESCRIPTION
## 연관된 이슈

- #168 

## 작업 내용

로그인 안해도 계속 대시보드 초대 확인을 해서 콘솔 에러가 나옵니다
로그인한 상태에서만 확인하도록 수정했습니다

- [x] 비로그인 시 알림 호출 못하게 수정

## 코멘트 및 논의 사항

@un0211 혜원님 이대로 해도 괜찮은지 확인해주세요! 🫡
