### PR TITLE
🛠  fix(#200): 같은 대시보드 초대를 하나만 받을 수 있도록 수정

### DIFF
--- a/src/containers/mydashboard/InvitedDashboardList/ItemList.tsx
+++ b/src/containers/mydashboard/InvitedDashboardList/ItemList.tsx
@@ -6,7 +6,7 @@ import { Invitation } from '@/types/Invitation.interface';
 
 interface InvitationListProps {
   invitations: Invitation[];
-  handleAcceptInvitation: (invitationId: number, inviteAccepted: boolean) => void;
+  handleAcceptInvitation: (invitationId: number, inviteAccepted: boolean, dashboardId: number) => void;
   observerRef: React.RefObject<HTMLDivElement>;
 }
 
@@ -42,13 +42,13 @@ export default function InvitationItemList({ invitations, handleAcceptInvitation
               </div>
               <div className='flex items-center gap-[10px]'>
                 <ActionButton
-                  onClick={() => handleAcceptInvitation(invitation.id, true)}
+                  onClick={() => handleAcceptInvitation(invitation.id, true, invitation.dashboard.id)}
                   className='w-[84px] grow lg:grow-0'
                 >
                   수락
                 </ActionButton>
                 <CancelButton
-                  onClick={() => handleAcceptInvitation(invitation.id, false)}
+                  onClick={() => handleAcceptInvitation(invitation.id, false, invitation.dashboard.id)}
                   className='w-[84px] grow lg:grow-0'
                 >
                   거절


### PR DESCRIPTION
## 연관된 이슈

- close #200 

## 작업 내용

같은 대시보드 초대를 하나만 받을 수 있도록 수정

## 스크린샷

![aaa](https://github.com/Part3-Team15/taskify/assets/89517903/b232896a-43e3-405b-8e39-36e342aba536)


## 코멘트 및 논의 사항

초대 받은 대시보드와 같은 대시보드는 수락을 했을때 나머지는 전부 거절하게 만들었습니다
