### PR TITLE
❗️ HOTFIX(#24): 대시보드 생성자 멤버 삭제 불가능하게 변경

### DIFF
--- a/src/containers/dashboard/edit/MemberItem.tsx
+++ b/src/containers/dashboard/edit/MemberItem.tsx
@@ -1,5 +1,8 @@
+import { useSelector } from 'react-redux';
+
 import CancelButton from '@/components/Button/CancelButton';
 import ProfileIcon from '@/components/ProfileIcon';
+import { RootState } from '@/store/store';
 import { Member } from '@/types/Member.interface';
 
 interface InvitedMemberProps {
@@ -8,6 +11,8 @@ interface InvitedMemberProps {
 }
 
 export default function MemberItem({ member, onDeleteClick }: InvitedMemberProps) {
+  const { user } = useSelector((state: RootState) => state.user);
+
   return (
     <div className='flex items-center justify-between'>
       <div className='flex items-center gap-2 md:gap-3'>
@@ -20,7 +25,7 @@ export default function MemberItem({ member, onDeleteClick }: InvitedMemberProps
         />
         <p className='text-base font-medium'>{member.nickname}</p>
       </div>
-      <CancelButton type='button' className='text-sm' onClick={onDeleteClick}>
+      <CancelButton type='button' className='text-sm' onClick={onDeleteClick} disabled={user?.id === member.userId}>
         삭제
       </CancelButton>
     </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -14,7 +14,7 @@
   }
 
   .btn-violet-light {
-    @apply align-center gray-border rounded-[8px] bg-white transition-all hover:bg-violet-light-hover active:bg-violet-light-active disabled:bg-violet-light-disabled;
+    @apply align-center gray-border rounded-[8px] bg-white transition-all hover:bg-violet-light-hover active:bg-violet-light-active disabled:bg-violet-light-disabled disabled:text-gray-78;
   }
 
   .btn-white {
@@ -26,7 +26,7 @@
   }
 
   .btn-red {
-    @apply align-center active:bg-red-active rounded-[8px] bg-red text-white transition-all hover:bg-red-hover disabled:bg-violet-disabled;
+    @apply align-center rounded-[8px] bg-red text-white transition-all hover:bg-red-hover active:bg-red-active disabled:bg-violet-disabled;
   }
 
   .section {


### PR DESCRIPTION
## 연관된 이슈

- #24

## 작업 내용

대시보드 생성자 멤버 삭제 불가능하게 변경했습니다!!
글자색도 바꿨어요

## 스크린샷
<img width="551" alt="image" src="https://github.com/Part3-Team15/taskify/assets/24778465/75a7416b-1e58-4620-8e6a-da3b123635c3">

## 코멘트 및 논의 사항

다들 화이팅입니다!! 버그찾기 / 고치기 / 개선하기도 화이팅하고 마무리 정리도 잘해봐요~~