### PR TITLE
🛠  Fix(#153): 다크모드로 바뀐 버튼 디자인 복귀

### DIFF
--- a/src/containers/dashboard/edit/index.tsx
+++ b/src/containers/dashboard/edit/index.tsx
@@ -88,7 +88,7 @@ export default function DashboardEdit() {
       </div>
       <button
         type='button'
-        className='gray-border flex size-fit min-w-[235px] items-center justify-center rounded-lg bg-violet/70 py-4 text-xl font-bold text-white md:my-12 md:px-20 md:py-5 md:text-lg dark:bg-violet-hover/60'
+        className='btn-gray gray-border my-8 size-fit rounded-lg px-[84px] py-4 text-base font-medium md:my-12 md:px-[95px] md:py-5 md:text-lg dark:bg-violet/40 dark:text-white dark:hover:bg-violet-hover/60 dark:active:bg-violet-hover/70'
         onClick={handleDeleteClick}
       >
         대시보드 삭제하기


### PR DESCRIPTION
## 연관된 이슈

- #153

## 작업 내용

- 다크모드로 대시보드 삭제 버튼색상이 바뀌었는데 원상복귀했습니다!

## 스크린샷
<img width="292" alt="image" src="https://github.com/Part3-Team15/taskify/assets/24778465/84b97e8d-b5c0-44bc-8753-6860d3a07d9e">

<img width="326" alt="image" src="https://github.com/Part3-Team15/taskify/assets/24778465/51d8b0e7-3f27-405a-9c16-5d650efed4a6">

