### PR TITLE
🛠  fix(#214): 할 일 수정에서 컬럼 변동 시 두 컬럼 모두 새로고침하도록 수정

### DIFF
--- a/src/components/Modal/EditCardModal/index.tsx
+++ b/src/components/Modal/EditCardModal/index.tsx
@@ -270,6 +270,9 @@ export default function EditCardModal({ column, isEdit = false, card }: EditCard
       }
 
       queryClient.invalidateQueries({ queryKey: ['cards', column.id] });
+      if (formValues.columnId !== column.id) {
+        queryClient.invalidateQueries({ queryKey: ['cards', formValues.columnId] });
+      }
     } catch (error) {
       console.error('Error submitting form:', error);
     } finally {


### PR DESCRIPTION
## 연관된 이슈

- #214

## 작업 내용

컬럼 이동 시 기존 컬럼에서는 바로 사라지지만, 새 컬럼에 바로 나타나지 않는 문제 발견 (아래 영상)
-> 새 컬럼도 새로고침하도록 변경

https://github.com/Part3-Team15/taskify/assets/24778465/0237ab69-2e2b-47d1-ab01-0d4d0a259c5c

