### PR TITLE
🛠  fix(#198): 첫 번째 초대도 알람 올 수 있게 변경

### DIFF
--- a/src/components/InviteNotice/index.tsx
+++ b/src/components/InviteNotice/index.tsx
@@ -9,26 +9,36 @@ import { Invitation, InvitationsResponse } from '@/types/Invitation.interface';
 
 export default function InvitationNotice() {
   // NOTE: 3초마다 refetch 하도록 설정
-  const { data } = useFetchData<InvitationsResponse>(['invitations', 'notice'], () => getInvitationsList(), 5000);
-  const [savedInvitations, setSavedInvitations] = useState<Invitation[]>(data?.invitations || []);
+  const { data, isSuccess } = useFetchData<InvitationsResponse>(
+    ['invitations', 'notice'],
+    () => getInvitationsList(),
+    5000,
+  );
+  const [savedInvitations, setSavedInvitations] = useState<Invitation[] | null>(data?.invitations || null);
 
   useEffect(() => {
-    if (
-      data &&
-      data.invitations[0] &&
-      savedInvitations[0] &&
-      data.invitations[0].createdAt >= savedInvitations[0].createdAt
-    ) {
-      for (let i = 0; i < data.invitations.length; i += 1) {
-        const invitation = data.invitations[i];
-        if (invitation.createdAt <= savedInvitations[0].createdAt) break;
-        toast.info(
-          `${invitation.inviter.nickname}님이 ${invitation.dashboard.title}에 초대했어요!`,
-          TOAST_DEFAULT_SETTING,
+    if (data && data.invitations[0] && savedInvitations) {
+      if (savedInvitations.length === 0) {
+        data.invitations.forEach((invitation) =>
+          toast.info(
+            `${invitation.inviter.nickname}님이 ${invitation.dashboard.title}에 초대했어요!`,
+            TOAST_DEFAULT_SETTING,
+          ),
         );
+      } else if (savedInvitations[0] && data.invitations[0].createdAt >= savedInvitations[0].createdAt) {
+        for (let i = 0; i < data.invitations.length; i += 1) {
+          const invitation = data.invitations[i];
+          if (invitation.createdAt <= savedInvitations[0].createdAt) break;
+          toast.info(
+            `${invitation.inviter.nickname}님이 ${invitation.dashboard.title}에 초대했어요!`,
+            TOAST_DEFAULT_SETTING,
+          );
+        }
       }
     }
-    setSavedInvitations(data?.invitations || []);
+    if (isSuccess) {
+      setSavedInvitations(data.invitations);
+    }
   }, [data]);
 
   return <ToastContainer />;


### PR DESCRIPTION
## 연관된 이슈

- #198

## 작업 내용

- 첫 번째 알람에도 초대가 올 수 있게 초기값을 null로 변경하고, 결과가 제대로 왔을 때 실제 배열로 초기화했습니다.