### PR TITLE
🛠  Fix(#234): 즐겨찾기 간단한 수정

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -124,7 +124,7 @@ export default function Sidebar() {
         {favoriteList && favoriteList.length > 0 && (
           <>
             <div className='flex flex-col items-stretch gap-2'>
-              <p className='flex items-center text-lg text-gray-78 md:px-3 dark:text-dark-10'>
+              <p className='align-center text-lg text-gray-78 md:px-3 dark:text-dark-10'>
                 ⭐
                 <span className='hidden px-2 text-[14px] font-extrabold text-gray-78 md:block dark:text-dark-10'>
                   즐겨찾기

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -123,7 +123,7 @@ export default function Sidebar() {
 
         {favoriteList && favoriteList.length > 0 && (
           <>
-            <div className='flex flex-col items-center gap-2 md:items-stretch'>
+            <div className='flex flex-col items-stretch gap-2'>
               <p className='flex items-center text-lg text-gray-78 md:px-3 dark:text-dark-10'>
                 ⭐
                 <span className='hidden px-2 text-[14px] font-extrabold text-gray-78 md:block dark:text-dark-10'>

--- a/src/containers/dashboard/edit/DashboardModifySection.tsx
+++ b/src/containers/dashboard/edit/DashboardModifySection.tsx
@@ -127,7 +127,7 @@ export default function DashboardModifySection({ initIsPublic, onPublicChange }:
       openNotificationModal({ text: '대시보드 정보가 수정되었습니다!' });
       queryClient.invalidateQueries({ queryKey: ['dashboard', id] });
       queryClient.invalidateQueries({ queryKey: ['sideDashboards'] });
-      queryClient.invalidateQueries({ queryKey: ['sideFavorites'] });
+      queryClient.invalidateQueries({ queryKey: ['favorites'] });
 
       setIsButtonDisabled(true);
     } catch {

--- a/src/containers/dashboard/edit/DashboardModifySection.tsx
+++ b/src/containers/dashboard/edit/DashboardModifySection.tsx
@@ -189,7 +189,7 @@ export default function DashboardModifySection({ initIsPublic, onPublicChange }:
   }
 
   return (
-    <section className='section relative flex h-[211px] flex-col justify-between px-[18px] py-[22px] transition-colors md:h-[256px] md:py-[26px] dark:bg-dark'>
+    <section className='section relative flex flex-col gap-4 px-[18px] py-[22px] transition-colors md:gap-6 md:py-[26px] dark:bg-dark'>
       <header className='flex justify-between'>
         <h2 className='text-[20px] font-bold text-black-33 dark:text-dark-10'>{fixedTitle}</h2>
         <div className='flex flex-col gap-2 md:flex-row'>


### PR DESCRIPTION
## 연관된 이슈

- close #234

## 작업 내용

- 사이드바 즐겨찾기 모바일의 호버/클릭 디자인 개선
- 대시보드 이름과 버튼 간격 개선
- 쿼리 키 통일

## 스크린샷

|전|후|
|-|-|
|<img width="371" src="https://github.com/Part3-Team15/taskify/assets/24778465/2569c213-2311-4406-ae27-ad1c69fa100a" />|<img width="371" alt="image" src="https://github.com/Part3-Team15/taskify/assets/24778465/db034fab-0554-42a6-b984-426fb42d8914">|

