### PR TITLE
♻️ Refactor: Tanstack Query 캐싱 리팩토링

### DIFF
--- a/src/components/Modal/TodoCardModal/index.tsx
+++ b/src/components/Modal/TodoCardModal/index.tsx
@@ -56,26 +56,7 @@ export default function TodoCardModal({ card, column, onClick }: TodoCardModalPr
     }
   };
 
-  const handleObserver = useCallback(
-    (entries: IntersectionObserverEntry[]) => {
-      const target = entries[0];
-      if (target.isIntersecting && cursorId !== null && !isFetching) {
-        fetchComments(5, cursorId);
-      }
-    },
-    [cursorId, isFetching],
-  );
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(handleObserver, {
-      threshold: 1.0,
-    });
-    if (observerRef.current) observer.observe(observerRef.current);
-
-    return () => {
-      if (observerRef.current) observer.unobserve(observerRef.current);
-    };
-  }, [handleObserver]);
+  const { observerRef } = useInfiniteScroll(fetchComments, cursorId, isFetching); // 무한 스크롤 옵저버 참조
 
   useEffect(() => {
     queryClient.invalidateQueries({ queryKey: ['comments', card.id] });

--- a/src/components/Modal/TodoCardModal/index.tsx
+++ b/src/components/Modal/TodoCardModal/index.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import { FormEvent, useEffect, useState, useRef, useCallback } from 'react';
+import { FormEvent, useEffect, useState } from 'react';
 
 import Comment from './Comment';
 import EditDropdown from './EditDropdown';
@@ -9,6 +9,7 @@ import EditDropdown from './EditDropdown';
 import ProfileIcon from '@/components/ProfileIcon';
 import Tags from '@/components/Tags';
 import useFetchData from '@/hooks/useFetchData';
+import useInfiniteScroll from '@/hooks/useInfiniteScroll';
 import useModal from '@/hooks/useModal';
 import { getComments } from '@/services/getService';
 import { postComment } from '@/services/postService';

--- a/src/components/Modal/TodoCardModal/index.tsx
+++ b/src/components/Modal/TodoCardModal/index.tsx
@@ -18,12 +18,10 @@ import { CommentsResponse, CommentForm, Comment as CommentType } from '@/types/p
 import formatDate from '@/utils/formatDate';
 
 export default function TodoCardModal({ card, column, onClick }: TodoCardModalProps) {
-  const [comments, setComments] = useState<CommentType[]>([]);
-  const [cursorId, setCursorId] = useState<number | null>(null);
-  const [isFetching, setIsFetching] = useState(false);
-  const observerRef = useRef<HTMLDivElement | null>(null);
-  const [newComment, setNewComment] = useState('');
-  const [isCommentEmpty, setIsCommentEmpty] = useState(true);
+  const [comments, setComments] = useState<CommentType[]>([]); // 패칭된 댓글 목록 State
+  const [newComment, setNewComment] = useState(''); // 댓글 입력 폼 State
+  const [cursorId, setCursorId] = useState<number | null>(null); // 다음 댓글의 커서 ID
+  const [isFetching, setIsFetching] = useState(false); // 댓글을 불러오는 중인지 여부
   const { closeModal } = useModal();
   const router = useRouter();
   const { id: dashboardId } = router.query;
@@ -81,13 +79,12 @@ export default function TodoCardModal({ card, column, onClick }: TodoCardModalPr
       dashboardId: Number(dashboardId),
     };
 
+    // 댓글 추가 후, 댓글 목록 쿼리 무효화를 통한 최신화
     try {
       await postComment(commentData);
       queryClient.invalidateQueries({ queryKey: ['comments', card.id] });
       setNewComment('');
-      setIsCommentEmpty(true); // 성공 시 에러 메시지 초기화
     } catch (error) {
-      setIsCommentEmpty(true);
       console.error(error);
     }
   };
@@ -149,7 +146,7 @@ export default function TodoCardModal({ card, column, onClick }: TodoCardModalPr
                 <button
                   className='btn-violet-light dark:btn-white absolute right-1 h-[28px] w-[60px] rounded-[4px] text-[12px] text-violet md:h-[32px] md:w-[78px] lg:w-[84px] dark:rounded-[4px]'
                   type='submit'
-                  disabled={isCommentEmpty}
+                  disabled={newComment === ''}
                 >
                   입력
                 </button>

--- a/src/components/Modal/TodoCardModal/index.tsx
+++ b/src/components/Modal/TodoCardModal/index.tsx
@@ -27,7 +27,8 @@ export default function TodoCardModal({ card, column, onClick }: TodoCardModalPr
   const { id: dashboardId } = router.query;
   const queryClient = useQueryClient();
 
-  const { data, refetch } = useFetchData<CommentsResponse>(['comments', card.id], () => getComments(card.id, 10));
+  // 댓글 목록 데이터 패칭
+  const { data } = useFetchData<CommentsResponse>(['comments', card.id], () => getComments(card.id, 10));
 
   useEffect(() => {
     if (data) {
@@ -36,6 +37,7 @@ export default function TodoCardModal({ card, column, onClick }: TodoCardModalPr
     }
   }, [data]);
 
+  // 댓글 목록 패칭 함수
   const fetchComments = async (size: number, cursor?: number | null) => {
     setIsFetching(true);
     try {
@@ -43,9 +45,9 @@ export default function TodoCardModal({ card, column, onClick }: TodoCardModalPr
       const newComments = response.data.comments;
       setComments((prevComments) => [...prevComments, ...newComments]);
       if (newComments.length < size) {
-        setCursorId(null);
+        setCursorId(null); // 더 이상 불러올 댓글이 없음
       } else {
-        setCursorId(newComments[newComments.length - 1].id);
+        setCursorId(newComments[newComments.length - 1].id); // 다음 커서 ID 업데이트
       }
     } catch (error) {
       console.error('Error fetching comments:', error);
@@ -56,19 +58,17 @@ export default function TodoCardModal({ card, column, onClick }: TodoCardModalPr
 
   const { observerRef } = useInfiniteScroll(fetchComments, cursorId, isFetching); // 무한 스크롤 옵저버 참조
 
+  // 할일 카드 모달을 띄울 때, 댓글 목록 쿼리 무효화
   useEffect(() => {
     queryClient.invalidateQueries({ queryKey: ['comments', card.id] });
   }, [queryClient, card.id]);
-
-  useEffect(() => {
-    setIsCommentEmpty(newComment.trim().length === 0);
-  }, [newComment]);
 
   const handleModalClose = () => {
     if (onClick) onClick();
     closeModal();
   };
 
+  // 댓글 작성 처리 핸들러
   const handleSubmitComment = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 

--- a/src/containers/dashboard/Column.tsx
+++ b/src/containers/dashboard/Column.tsx
@@ -1,11 +1,12 @@
 import Image from 'next/image';
-import { useEffect, useRef, useCallback, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Draggable, Droppable } from 'react-beautiful-dnd';
 
 import Card from './Card';
 import ColumnSkeleton from './ColumnSkeleton';
 
 import useFetchData from '@/hooks/useFetchData';
+import useInfiniteScroll from '@/hooks/useInfiniteScroll';
 import useModal from '@/hooks/useModal';
 import { getCardsList } from '@/services/getService';
 import { Card as CardType, CardsListResponse } from '@/types/Card.interface';
@@ -60,19 +61,7 @@ function Column({ column, columns, isMember }: ColumnProps) {
     [column.id],
   );
 
-  const lastCardRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (isFetching) return;
-      if (observer.current) observer.current.disconnect();
-      observer.current = new IntersectionObserver((entries) => {
-        if (entries[0].isIntersecting && cursorId !== 0) {
-          fetchCards(5, cursorId);
-        }
-      });
-      if (node) observer.current.observe(node);
-    },
-    [isFetching, cursorId, fetchCards],
-  );
+  const { observerRef } = useInfiniteScroll(fetchCards, cursorId, isFetching);
 
   if (isLoading) {
     return <ColumnSkeleton />;

--- a/src/containers/dashboard/Column.tsx
+++ b/src/containers/dashboard/Column.tsx
@@ -23,9 +23,8 @@ function Column({ column, columns, isMember }: ColumnProps) {
   const { openModifyColumnModal, openEditCardModal, openTodoCardModal } = useModal();
   const [cards, setCards] = useState<CardType[]>([]);
   const [totalCount, setTotalCount] = useState<number>(0);
-  const [cursorId, setCursorId] = useState<number | 0>(0);
+  const [cursorId, setCursorId] = useState<number | null>(null);
   const [isFetching, setIsFetching] = useState(false);
-  const observer = useRef<IntersectionObserver | null>(null);
 
   const {
     data: initialData,
@@ -37,20 +36,20 @@ function Column({ column, columns, isMember }: ColumnProps) {
     if (initialData) {
       setCards(initialData.cards);
       setTotalCount(initialData.totalCount);
-      setCursorId(initialData.cursorId || 0);
+      setCursorId(initialData.cursorId || null);
     }
   }, [initialData]);
 
   const fetchCards = useCallback(
-    async (size: number, cursorId?: number) => {
+    async (size: number, cursorId?: number | null) => {
       setIsFetching(true);
       try {
-        const response = await getCardsList(column.id, size, cursorId);
+        const response = await getCardsList(column.id, size, cursorId !== null ? cursorId : undefined);
         if (response.data.cards.length > 0) {
           setCards((prevCards) => [...prevCards, ...response.data.cards]);
-          setCursorId(response.data.cursorId || 0);
+          setCursorId(response.data.cursorId || null);
         } else {
-          setCursorId(0);
+          setCursorId(null);
         }
       } catch (error) {
         console.error('Error fetching cards:', error);
@@ -68,7 +67,7 @@ function Column({ column, columns, isMember }: ColumnProps) {
   }
 
   if (error) {
-    return <div>Error loading cards: {error.message}</div>;
+    return <>{error.message}</>;
   }
 
   return (
@@ -128,7 +127,7 @@ function Column({ column, columns, isMember }: ColumnProps) {
                       <div
                         ref={(cardRef) => {
                           provided.innerRef(cardRef);
-                          if (index === cards.length - 1) lastCardRef(cardRef);
+                          if (index === cards.length - 1) observerRef.current = cardRef;
                         }}
                         {...provided.draggableProps}
                         {...provided.dragHandleProps}
@@ -140,7 +139,7 @@ function Column({ column, columns, isMember }: ColumnProps) {
                   </Draggable>
                 ))}
                 {isFetching &&
-                  Array.from({ length: 1 }).map((card, index) => (
+                  Array.from({ length: 1 }).map((_, index) => (
                     <div key={index} className='align-center py-3 opacity-50 invert dark:invert-0'>
                       <Image src='/icons/spinner.svg' alt='스피너 아이콘' width={20} height={20} />
                     </div>

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+const useInfiniteScroll = (
+  fetchData: (size: number, cursorId?: number | null) => Promise<void>,
+  cursorId: number | null,
+  isFetching: boolean,
+) => {
+  const observerRef = useRef<HTMLDivElement | null>(null); // 무한 스크롤 옵저버 참조
+
+  // 댓글 목록 무한 스크롤 옵저버
+  const handleObserver = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const target = entries[0];
+      if (target.isIntersecting && cursorId !== null && !isFetching) {
+        fetchData(5, cursorId);
+      }
+    },
+    [cursorId, isFetching, fetchData],
+  );
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(handleObserver, {
+      threshold: 1.0,
+    });
+    if (observerRef.current) observer.observe(observerRef.current);
+
+    return () => {
+      if (observerRef.current) observer.unobserve(observerRef.current);
+    };
+  }, [handleObserver]);
+
+  return { observerRef };
+};
+
+export default useInfiniteScroll;


### PR DESCRIPTION
## 연관된 이슈

- close #232

## 작업 내용
캐싱을 **`invalidateQueries`** 함수로 처리했습니다.

- [x] `TodoCardModal.tsx` : 컴포넌트 마운트/언마운트에 따른 캐싱 처리
- [x]  대시보드 페이지 : 쿼리키 등 캐싱 효율을 높이기 위한 방안 적용
- [x]  `useInfiniteScroll` : 무한스크롤 로직 커스텀훅으로 분리
- [x] 주석 추가

## 스크린샷

## 코멘트 및 논의 사항
invalidateQueries, refetch 중 어떤걸 써야할지 고민했습니다.


### Case : 모달 내 댓글 목록을 가져올 때 (댓글 추가/수정/삭제 등 변경 사항 발생가능)

**invalidateQueries** : 쿼리를 무효화해 다음 번에 필요할 때 데이터를 새로 가져옵니다. 불필요하게 데이터를 재요청할 필요가 없고, 퍼포먼스 최적화에도 좋습니다. 대부분의 경우, invalidate는 데이터 변동이 발생(데이터를 수정하는 mutation 작업이 성공)한 후 호출됩니다.

```ts
useEffect(() => {
  queryClient.invalidateQueries({ queryKey: ['comments', card.id] });
}, [queryClient, card.id]);
```

**refetch** : 데이터를 즉시 다시 가져오며, 유저가 직접 쿼리를 다시 실행하고 싶을 때 유용합니다. 예를 들어 데이터를 최신 상태로 갱신하고 싶을 때 '새로 고침' 버튼을 클릭해 refetch를 사용할 수 있습니다.
```ts
refetch
useEffect(() => {
  refetch();
}, [refetch]);
```

따라서 **댓글 목록**, **카드 목록** 등은 데이터가 변경되면 바로 반영되야 하는 동시에, 데이터가 변경될 때만 최신데이터를 가져오면 되기 때문에 invalidateQueries가 더 적합하다고 판단했습니다.

